### PR TITLE
Update arrows and readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ screen-powerline
 
 A [powerline](https://github.com/powerline/powerline)-inspired config for GNU Screen.
 
-It requires a font patched for vim-powerline. A list of patched fonts can be found at the
+It requires a font patched for powerline. A list of patched fonts can be found at the
 [powerline RTD](https://powerline.readthedocs.org/en/latest/installation.html#patched-fonts).
 
 For help setting up a clean UTF-8 environment, [here's an oldie from Moritz Lenz](http://perlgeek.de/en/article/set-up-a-clean-utf8-environment).

--- a/README.md
+++ b/README.md
@@ -1,15 +1,9 @@
 screen-powerline
 ================
 
-A [vim-powerline](https://github.com/Lokaltog/vim-powerline) inspired config for GNU Screen.
+A [powerline](https://github.com/powerline/powerline)-inspired config for GNU Screen.
 
 It requires a font patched for vim-powerline. A list of patched fonts can be found at the
-[vim-powerline Wiki](https://github.com/Lokaltog/vim-powerline/wiki/Patched-fonts).
+[powerline RTD](https://powerline.readthedocs.org/en/latest/installation.html#patched-fonts).
 
-**This won't work most of the time because of crappy utf8 support in screen.
-It might be a better idea to use tmux instead.**
-
-Screenshot
-----------
-
-![Screenshot](http://bseibold.github.com/screen-powerline/images/screenshot.png)
+For help setting up a clean UTF-8 environment, [here's an oldie from Moritz Lenz](http://perlgeek.de/en/article/set-up-a-clean-utf8-environment).

--- a/screenrc
+++ b/screenrc
@@ -4,4 +4,4 @@ startup_message off
 term "screen-256color"
 
 caption always "%{kY} %n%f* %t %?%{YR}%{kR} %u %{Rb}%:%{Yb}%?%?%F%{.b}%:%{.w}%?%="
-hardstatus alwayslastline "%{bk} %S %{kb} $LOGNAME %{bk} %H %?%{kb}%{kY} %-Lw%{Yk}%:%{Yb}⮀%{Yk}%?%{Yk} %n%f* %t %{kY}%+Lw %-="
+hardstatus alwayslastline "%{bk} %S %{kb} $LOGNAME %{bk} %H %?%{kb}%{kY} %-Lw%{Yk}%:%{Yb}%{Yk}%?%{Yk} %n%f* %t %{kY}%+Lw %-="

--- a/screenrc
+++ b/screenrc
@@ -4,4 +4,4 @@ startup_message off
 term "screen-256color"
 
 caption always "%{kY} %n%f* %t %?%{YR}%{kR} %u %{Rb}%:%{Yb}%?%?%F%{.b}%:%{.w}%?%="
-hardstatus alwayslastline "%{bk} %S %{kb} $LOGNAME %{bk} %H %?%{kb}%{kY} %-Lw%{Yk}%:%{Yb}⮀%{Yk}%?%{Yk} %n%f* %t %{kY}⮀%+Lw %-="
+hardstatus alwayslastline "%{bk} %S %{kb} $LOGNAME %{bk} %H %?%{kb}%{kY} %-Lw%{Yk}%:%{Yb}⮀%{Yk}%?%{Yk} %n%f* %t %{kY}%+Lw %-="

--- a/screenrc
+++ b/screenrc
@@ -3,6 +3,5 @@ utf8 on on
 startup_message off
 term "screen-256color"
 
-caption always "%{kY} %n%f* %t %?%{YR}⮀%{kR} %u %{Rb}%:%{Yb}%?%?%F%{.b}⮀%:%{.w}⮀%?%="
-hardstatus alwayslastline "%{bk} %S %{kb}⮀ $LOGNAME %{bk}⮀ %H %?%{kb}⮀%{kY} %-Lw%{Yk}⮀%:%{Yb}⮀%{Yk}%?%{Yk} %n%f* %t %{kY}⮀%+Lw %-="
-
+caption always "%{kY} %n%f* %t %?%{YR}%{kR} %u %{Rb}%:%{Yb}%?%?%F%{.b}%:%{.w}%?%="
+hardstatus alwayslastline "%{bk} %S %{kb} $LOGNAME %{bk} %H %?%{kb}%{kY} %-Lw%{Yk}%:%{Yb}⮀%{Yk}%?%{Yk} %n%f* %t %{kY}⮀%+Lw %-="


### PR DESCRIPTION
Change the arrows from U+2B80 to U+E0B0 to suit newer Powerline fonts. Update links in the readme and references to Powerline, and remove a broken screenshot.
